### PR TITLE
Push to ssl-hep Dockerhub

### DIFF
--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -22,6 +22,6 @@ jobs:
       env:
         USERNAME: ${{ secrets.DOCKER_USERNAME }}
         PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: "gordonwatts/servicex_code_gen_funcadl_xaod"
+        IMAGE_NAME: "sslhep/servicex_code_gen_funcadl_xaod"
         LATEST: FALSE
         TAG_NAME: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -11,17 +11,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1.2.0
 
-    - name: Extract branch name
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
-      id: extract_branch      
-
-    - name: Build and Push Docker Image
-      # See https://github.com/marketplace/actions/docker-push
-      uses: opspresso/action-docker@master
-      env:
-        USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        IMAGE_NAME: "sslhep/servicex_code_gen_funcadl_xaod"
-        LATEST: FALSE
-        TAG_NAME: ${{ steps.extract_branch.outputs.branch }}
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: sslhep/servicex_xaod_cpp_transformer
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tag_names: true


### PR DESCRIPTION
# Problem 
The GitHub Actions are publishing to @gordonwatts docker hub account. We need to publish to the ssl-hep org.

# Approach 
Updated the Secrets in the repo and changed the image name.
Found a simpler way to use the branch name as the tag and switched to it