### PR TITLE
Add calls to file-level status posts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-servicex-transformer==0.4.0
+servicex-transformer==0.4.1
 requests>=2.22.0
 kafka-python
 confluent_kafka==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-servicex-transformer==0.3.rc1
+servicex-transformer==0.4.0
 requests>=2.22.0
 kafka-python
 confluent_kafka==1.2.0

--- a/transformer_uproot.py
+++ b/transformer_uproot.py
@@ -151,8 +151,9 @@ def transform_single_file(file_path, output_path, servicex=None, tree_name='Even
             "Failed to transform input file " + file_path + ": " + str(exc_value))
 
     if messaging:
-        arrow_writer = ArrowWriter(file_format=args.result_format, servicex=servicex,
-                                   object_store=None, messaging=messaging)
+        arrow_writer = ArrowWriter(file_format=args.result_format,
+                                   object_store=None,
+                                   messaging=messaging)
 
         #Todo implement chunk size parameter
         transformer = ArrowIterator(arrow, chunk_size=1000, file_path=file_path)

--- a/transformer_xaod.py
+++ b/transformer_xaod.py
@@ -140,8 +140,9 @@ def transform_single_file(file_path, output_path, servicex=None):
         flat_tree_name = flat_file.keys()[0]
         attr_name_list = flat_file[flat_tree_name].keys()
 
-        arrow_writer = ArrowWriter(file_format=args.result_format, servicex=servicex,
-                                   object_store=object_store, messaging=messaging)
+        arrow_writer = ArrowWriter(file_format=args.result_format,
+                                   object_store=object_store,
+                                   messaging=messaging)
         # NB: We're converting the *output* ROOT file to Arrow arrays
         # TODO: Implement configurable chunk_size
         event_iterator = UprootEvents(file_path=output_path, tree_name=flat_tree_name,


### PR DESCRIPTION
# Problem 
Diagnosing some issues with Transformers can be difficult. The logs are spread across hundreds of pods. 

# Approach
Use the new file-level logging call in the ServiceX Transformer library to record when files are open, on each retry, upon success or failure.