### PR TITLE
Add output from Kafka timings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-servicex-transformer==0.4.1
+servicex-transformer==0.4.4.post1
 requests>=2.22.0
 kafka-python
 confluent_kafka==1.2.0

--- a/transformer_xaod.py
+++ b/transformer_xaod.py
@@ -150,6 +150,7 @@ def transform_single_file(file_path, output_path, servicex=None):
         transformer = UprootTransformer(event_iterator)
         arrow_writer.write_branches_to_arrow(transformer=transformer, topic_name=args.request_id,
                                              file_id=None, request_id=args.request_id)
+        print("Kafka Timings: "+str(arrow_writer.messaging_timings))
 
 
 def compile_code():


### PR DESCRIPTION
# Problem
We can't tell how long different stages of the ArrowWriter function are taking

# Approach
Use the new version of the library and simply print out the timings for publishing each message to Kafka.

It's just a print of a list right now....