### PR TITLE
Improve Awkward Table serialization to Arrow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ coverage==4.5.2
 codecov==2.0.15
 uproot
 awkward>=0.12.0
+awkward1==0.2.19
 xxhash
 lz4
 pyarrow==0.16.0


### PR DESCRIPTION
- Remove the conversion of awkward Table to pandas DF
- Added `awkward1==0.2.19` in the `requirements.txt`
- Added prints for time measurements