### PR TITLE
Improve readme and remove the yum update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "cSpell.words": [
+        "Chunksize",
+        "brokerlist",
+        "columnwise",
+        "globus",
+        "servicex",
+        "sslhep",
+        "xaod"
+    ]
+}

--- a/Dockerfile.xaodTransformer
+++ b/Dockerfile.xaodTransformer
@@ -11,8 +11,8 @@ RUN sudo yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-rel
 RUN sudo curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg
 RUN sudo curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
 RUN sudo yum install -y xrootd-server xrootd-client xrootd \
-    vomsxrd voms-clients wlcg-voms-atlas fetch-crl osg-ca-certs \
-    xrootd-rucioN2N-for-Xcache
+    xrootd-voms voms-clients wlcg-voms-atlas fetch-crl osg-ca-certs
+#    xrootd-rucioN2N-for-Xcache
 
 # Install everything needed to host/run the analysis jobs
 RUN sudo mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir

--- a/Dockerfile.xaodTransformer
+++ b/Dockerfile.xaodTransformer
@@ -4,6 +4,16 @@ FROM atlas/analysisbase:21.2.102
 # x509 certs.
 # WARNING: THis is for CentOS (modern versions of analysisbase)
 # TODO: Ask about a better way to deal with this.
+#
+# "sudo yum -y update" breaks the container due to a bad path in some of the ATLAS RPM's.
+# So it must be disabled until it is fixed on the ATLAS end:
+#   https://sft.its.cern.ch/jira/browse/SPI-1654
+# Unfortunately, the lack of this means the rucioN2N won't work either due to a library
+# conflict. Once that jira is resolved:
+#   1. Remove the comment below
+#   1. Turn back on the rucioN2N installation below
+#   1. Test (access a xroot file, compile C++ code)
+#   1. Delete this comment. :-)
 # RUN sudo yum -y update
 
 RUN sudo yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm

--- a/Dockerfile.xaodTransformer
+++ b/Dockerfile.xaodTransformer
@@ -4,7 +4,7 @@ FROM atlas/analysisbase:21.2.102
 # x509 certs.
 # WARNING: THis is for CentOS (modern versions of analysisbase)
 # TODO: Ask about a better way to deal with this.
-RUN sudo yum -y update
+# RUN sudo yum -y update
 
 RUN sudo yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
 # RUN sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ServiceX Transformer that converts ATLAS xAOD files into columnwise data
 
 You can invoke the transformer from the command line. For example:
 
-```
+```bash
 > docker run --rm -it sslhep/servicex_xaod_cpp_transformer:latest python transformer.py --help
 usage: transformer.py [-h] [--brokerlist BROKERLIST] [--topic TOPIC]
                       [--chunks CHUNKS] [--tree TREE] [--attrs ATTR_NAMES]
@@ -46,6 +46,7 @@ optional arguments:
 
 You will need an X509 proxy avaiable as a mountable volume. The X509 Secret
 container can do using your credentials and cert:
+
 ```bash
 docker run --rm \
     --mount type=bind,source=$HOME/.globus,readonly,target=/etc/grid-certs \
@@ -54,8 +55,8 @@ docker run --rm \
     --name=x509-secrets sslhep/x509-secrets:latest
 ```
 
-
 ## Development
+
 ```bash
  python3 -m pip install -r requirements.txt
  python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps servicex
@@ -67,7 +68,7 @@ docker run --rm \
 
 Under tests you'll find input files needed to try this out. Use the following docker conmmand.
 
-```
+```bash
 docker run --rm -it \
   --mount type=volume,source=x509,target=/etc/grid-security-ro \
   --mount type=bind,source=$(pwd),target=/code \
@@ -79,6 +80,7 @@ docker run --rm -it \
 Then use `trasformer.py` and pass it the `--path` argument.
 
 For example:
+
 ```bash
  python transformer.py --path /data/jets_10_events.root --result-format root-file --output-dir /tmp --result-destination output-dir
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ServiceX_xAOD_CPP_transformer
 
-![](https://github.com/ssl-hep/ServiceX_xAOD_CPP_transformer/workflows/Docker%20Hub/badge.svg)
+![Badge](https://github.com/ssl-hep/ServiceX_xAOD_CPP_transformer/workflows/Docker%20Hub/badge.svg)
 
 ServiceX Transformer that converts ATLAS xAOD files into columnwise data
 
@@ -44,7 +44,7 @@ optional arguments:
                         Request ID to read from queue
 ```
 
-You will need an X509 proxy avaiable as a mountable volume. The X509 Secret
+You will need an X509 proxy available as a mountable volume. The X509 Secret
 container can do using your credentials and cert:
 
 ```bash
@@ -66,7 +66,7 @@ docker run --rm \
 
 #### Testing by running against known file and C++ files
 
-Under tests you'll find input files needed to try this out. Use the following docker conmmand.
+Under tests you'll find input files needed to try this out. Use the following docker command.
 
 ```bash
 docker run --rm -it \
@@ -77,7 +77,7 @@ docker run --rm -it \
   sslhep/servicex_xaod_cpp_transformer:latest bash
 ```
 
-Then use `trasformer.py` and pass it the `--path` argument.
+Then use `transformer.py` and pass it the `--path` argument.
 
 For example:
 


### PR DESCRIPTION
This PR makes two improvements:

- Minor updates to the readme file
- Remove the `yum upgrade` as part of the container build: the update was breaking the C++ compiler resulting in this error:

```
 Change Dir: /home/atlas/rel/build/CMakeFiles/CMakeTmp
    Run Build Command(s):/usr/bin/gmake cmTC_fbf74/fast
    /usr/bin/gmake -f CMakeFiles/cmTC_fbf74.dir/build.make CMakeFiles/cmTC_fbf74.dir/build
    gmake[1]: Entering directory `/home/atlas/rel/build/CMakeFiles/CMakeTmp'
    Building C object CMakeFiles/cmTC_fbf74.dir/testCCompiler.c.o
    /opt/lcg/gcc/8.3.0-eda0e/x86_64-centos7/bin/gcc    -o CMakeFiles/cmTC_fbf74.dir/testCCompiler.c.o   -c /home/atlas/rel/build/CMakeFiles/CMakeTmp/testCCompiler.c
    gcc: error trying to exec 'cc1': execvp: No such file or directory
    gmake[1]: *** [CMakeFiles/cmTC_fbf74.dir/testCCompiler.c.o] Error 1
```