### PR TITLE
Remove ATLAS references

### DIFF
--- a/Dockerfile.uprootTransformer
+++ b/Dockerfile.uprootTransformer
@@ -43,7 +43,7 @@ RUN /opt/conda/bin/pip install --no-cache-dir -r requirements.txt
 
 ENV X509_USER_PROXY /etc/grid-security/x509up
 
-WORKDIR /home/atlas
+WORKDIR /servicex
 COPY uproot_proxy_exporter.sh proxy-exporter.sh
 RUN chmod +x proxy-exporter.sh
 

--- a/Dockerfile.xaodTransformer
+++ b/Dockerfile.xaodTransformer
@@ -26,9 +26,9 @@ RUN sudo yum install -y xrootd-server xrootd-client xrootd \
 
 # Install everything needed to host/run the analysis jobs
 RUN sudo mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir
-WORKDIR /home/atlas
-COPY bashrc /home/atlas/.bashrc
-COPY bashrc /home/atlas/.bash_profile
+WORKDIR /workdir
+COPY bashrc /workdir/.bashrc
+COPY bashrc /workdir/.bash_profile
 COPY requirements.txt .
 RUN source /home/atlas/release_setup.sh; \
     python2 -m pip install --user safety==1.8.7

--- a/Dockerfile.xaodTransformer
+++ b/Dockerfile.xaodTransformer
@@ -26,9 +26,9 @@ RUN sudo yum install -y xrootd-server xrootd-client xrootd \
 
 # Install everything needed to host/run the analysis jobs
 RUN sudo mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir
-WORKDIR /workdir
-COPY bashrc /workdir/.bashrc
-COPY bashrc /workdir/.bash_profile
+WORKDIR /servicex
+COPY bashrc /servicex/.bashrc
+COPY bashrc /servicex/.bash_profile
 COPY requirements.txt .
 RUN source /home/atlas/release_setup.sh; \
     python2 -m pip install --user safety==1.8.7


### PR DESCRIPTION
Resolves issue [130](https://app.zenhub.com/workspaces/servicex-5caba4288d0ceb76ea94ae1f/issues/ssl-hep/servicex/130) by changing the references to /home/atlas to /servicex in the xAOD transformer Dockerfile.