### PR TITLE
Report Fatal Errors Back to App

### DIFF
--- a/validate_requests.py
+++ b/validate_requests.py
@@ -74,10 +74,12 @@ def validate_request(file_name):
         return False, "Could not compile generated code "+str(eek)
 
 
-def post_status_update(endpoint, status_msg):
+def post_status_update(endpoint, status_msg, severity='info'):
     requests.post(endpoint + "/status", data={
         "timestamp": datetime.datetime.now().isoformat(),
-        "status": status_msg
+        "severity": severity,
+        "source": "Preflight Check",
+        "info": status_msg
     })
 
 
@@ -102,7 +104,9 @@ def callback(channel, method, properties, body):
         post_status_update(service_endpoint,  "Request validated")
         post_transform_start(service_endpoint, info)
     else:
-        post_status_update(service_endpoint, "Validation Request failed "+info)
+        post_status_update(service_endpoint,
+                           "Validation Request failed "+info,
+                           severity='fatal')
 
     print(valid, info)
     channel.basic_ack(delivery_tag=method.delivery_tag)


### PR DESCRIPTION
# Problem
When the preflight check finds an error it never tells the app to start the transformers. This is correct, however it never actually tells the app that there is a problem so the user is left waiting for the transforms to start.

This is part of the solution to [serviceX issue 153](https://github.com/ssl-hep/ServiceX/issues/153)

# Approach
Take advantage of the new `severity` property in the body of the status POST endpoint. 
Fatal errors detected in the service now report back to the app with the correct severity.
