### PR TITLE
Reset Current Working Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,4 @@ COPY proxy-exporter.sh .
 COPY validate_requests.py .
 
 COPY transformer.py .
+WORKDIR /home/atlas


### PR DESCRIPTION
# Problem
In addressing ServiceX Issue 130, we moved the scripts to /servicex. This directory is owned by root and so the atlas user is unable to write there.

# Approach
Change the WORKDIR back to /home/atlas after all code is installed