### PR TITLE
Move user x509 cert proxy to /tmp dir

### DIFF
--- a/DockerfileATLASxAOD
+++ b/DockerfileATLASxAOD
@@ -27,7 +27,7 @@ ENV PYTHONUNBUFFERED=1
 ENV INSTANCE="atlas_xaod_cpp_transformer"
 ENV DESC="ATLAS xAOD CPP Transformer"
 
-ENV X509_USER_PROXY=/etc/grid-security/x509up
+ENV X509_USER_PROXY=/tmp/grid-security/x509up
 ENV X509_CERT_DIR /etc/grid-security/certificates
 
 # Copy over the source

--- a/proxy-exporter.sh
+++ b/proxy-exporter.sh
@@ -1,25 +1,28 @@
 #!/usr/bin/env bash
-mkdir -p /etc/grid-security
 
+proxydir=$(dirname ${X509_USER_PROXY})
+
+if [[ ! -d $proxydir ]]
+then
+    mkdir -p $proxydir
+fi
 
 while true; do
 
-    date
-
-    while true; do 
-        cp /etc/grid-security-ro/x509up /etc/grid-security
+    while true; do
+        cp /etc/grid-security-ro/x509up ${X509_USER_PROXY}
         RESULT=$?
         if [ $RESULT -eq 0 ]; then
-            echo "Got proxy."
-            chmod 600 /etc/grid-security/x509up
-            break 
+            echo "INFO $INSTANCE_NAME xAOD-Transformer none Got proxy."
+            chmod 600 ${X509_USER_PROXY}
+            break
         else
-            echo "Warning: An issue encountered when getting proxy."
+            echo "WARNING $INSTANCE_NAME xAOD-Transformer none An issue encountered when getting proxy."
             sleep 5
         fi
     done
 
-    # Refresh every 10 hours.
-    sleep 36000
+   # Refresh every hour
+   sleep 3600
 
 done


### PR DESCRIPTION
# Problem
OpenShift deployments can't write copies of the user proxy to /etc

Partial solution to [ServiceX Issue 364](https://github.com/ssl-hep/ServiceX/issues/364)

# Approach
Changed the X509_USER_PROXY to /tmp/grid-security/x509up