### PR TITLE
Posix volume support

### DIFF
--- a/transformer.py
+++ b/transformer.py
@@ -276,21 +276,6 @@ def transform_single_file(file_path, output_path, servicex=None):
             logger.error(mesg)
             raise RuntimeError(mesg)
 
-    if not object_store:
-        flat_file = uproot.open(output_path)
-        flat_tree_name = flat_file.keys()[0]
-        attr_name_list = flat_file[flat_tree_name].keys()
-
-        arrow_writer = ArrowWriter(file_format=args.result_format,
-                                   object_store=object_store,
-                                   messaging=messaging)
-        # NB: We're converting the *output* ROOT file to Arrow arrays
-        event_iterator = UprootEvents(file_path=output_path, tree_name=flat_tree_name,
-                                      attr_name_list=attr_name_list)
-        transformer = UprootTransformer(event_iterator)
-        arrow_writer.write_branches_to_arrow(transformer=transformer, topic_name=args.request_id,
-                                             file_id=None, request_id=args.request_id)
-        logger.info("Timings: "+str(arrow_writer.messaging_timings))
     return total_events, output_size
 
 

--- a/transformer.py
+++ b/transformer.py
@@ -49,6 +49,7 @@ MAX_RETRIES = 3
 
 messaging = None
 object_store = None
+posix_path = None
 
 
 def initialize_logging(request=None):
@@ -159,6 +160,9 @@ def callback(channel, method, properties, body):
                                 status_code="start",
                                 info=os.environ["DESC"])
 
+    if not os.path.isdir(posix_path):
+        os.makedirs(posix_path)
+
     tick = time.time()
 
     file_done = False
@@ -167,6 +171,7 @@ def callback(channel, method, properties, body):
     output_size = 0
     total_time = 0
     start_process_info = get_process_info()
+
     for attempt in range(MAX_RETRIES):
         for _file_path in _file_paths:
             try:
@@ -174,7 +179,7 @@ def callback(channel, method, properties, body):
                 # Do the transform
                 logger.info("Attempt {}. Trying path {}".format(attempt, _file_path))
                 root_file = _file_path.replace('/', ':')
-                output_path = '/home/atlas/' + root_file
+                output_path = os.path.join(posix_path, root_file)
                 logger.info("Processing {}, file id: {}".format(root_file, _file_id))
                 (total_events, output_size) = transform_single_file(
                     _file_path, output_path, servicex)
@@ -300,9 +305,14 @@ if __name__ == "__main__":
 
     logger = initialize_logging(args.request_id)
 
-    if not args.output_dir and args.result_destination == 'object-store':
-        messaging = None
+    if args.output_dir:
+        object_store = None
+    if args.result_destination == 'object-store':
+        posix_path = "/home/atlas"
         object_store = ObjectStoreManager()
+    elif args.result_destination == 'volume':
+        object_store = None
+        posix_path = args.output_dir
 
     compile_code()
     startup_time = get_process_info()


### PR DESCRIPTION
# Problem
The `volume` option for results destination was not implemented for the xAOD Transformer

# Approach
* Pull out the hardcoded `/home/atlas` destination for scratch file
* Allow this to be set from the --result_destination command line setting
* Removed some remaining Kafka code that was causing problems when object-store is not set 