### PR TITLE
Permissions changes for OKD/OpenShift compatibility

### DIFF
--- a/DockerfileCMSAOD
+++ b/DockerfileCMSAOD
@@ -23,3 +23,7 @@ RUN echo "#!/bin/bash" > proxy-exporter.sh &&\
 COPY transformer.py transformer-actual.py
 COPY transformer-shim.py transformer.py
 WORKDIR /home/atlas
+
+RUN chmod 755 /home/cmsusr/.local /home/cmsusr/.local/lib /home/cmsusr/.local/lib/python3.6 \
+              /home/cmsusr/.local/lib/python3.6/site-packages
+RUN chgrp 0 /home/atlas && chmod g+w /home/atlas


### PR DESCRIPTION
OpenShift/OKD runs containers as an ephemeral UID with GID 0.
This patch gives GID 0 write access to the output directory and
fixes some directories created with mode 700.

(It might make more sense to fix some of this in the upstream image (referenced here: https://github.com/ssl-hep/ServiceX_xAOD_CPP_transformer/blob/develop/DockerfileCMSAOD#L1)